### PR TITLE
Fix index out of bounds Exception (#8)

### DIFF
--- a/Madjic.Edi.Dom/Factory/ReaderFactory.vb
+++ b/Madjic.Edi.Dom/Factory/ReaderFactory.vb
@@ -9,43 +9,51 @@ Partial Friend NotInheritable Class ReaderFactory
     '''<param name="rdr">The transaction set reader that is examined for determining the type of transaction to return.</param>
     '''<returns>An object that inherits from TransactionSet or Nothing if the transaction set cannot be recognized.</returns>
     Friend Shared Function CreateTransaction(grp As FunctionalGroup, rdr As EdiReader.EdiTransactionSetReader) As TransactionSet
-        If String.Compare(grp.VersionCode, rdr.Element(2), StringComparison.OrdinalIgnoreCase) = 0 Then
-            If String.Compare(rdr.Element(2), "005010X279A1", StringComparison.OrdinalIgnoreCase) = 0 AndAlso
+        Dim ST03 As String
+
+        If rdr.ElementCount >= 3 Then
+            ST03 = rdr.Element(2)
+        Else
+            ST03 = grp.VersionCode
+        End If
+
+        If String.Compare(grp.VersionCode, ST03, StringComparison.OrdinalIgnoreCase) = 0 Then
+            If String.Compare(ST03, "005010X279A1", StringComparison.OrdinalIgnoreCase) = 0 AndAlso
                String.Compare(rdr.Element(0), "270", StringComparison.InvariantCultureIgnoreCase) = 0 AndAlso
                String.Compare(grp.FunctionalIdCode, "HS", StringComparison.Ordinal) = 0 Then
                 Return New Transactions.Transaction270.Standard_Obj("005010X279A1")
-            ElseIf String.Compare(rdr.Element(2), "005010X279A1", StringComparison.OrdinalIgnoreCase) = 0 AndAlso
+            ElseIf String.Compare(ST03, "005010X279A1", StringComparison.OrdinalIgnoreCase) = 0 AndAlso
                String.Compare(rdr.Element(0), "271", StringComparison.InvariantCultureIgnoreCase) = 0 AndAlso
                String.Compare(grp.FunctionalIdCode, "HB", StringComparison.Ordinal) = 0 Then
                 Return New Transactions.Transaction271.Standard_Obj("005010X279A1")
-            ElseIf String.Compare(rdr.Element(2), "005010X212", StringComparison.OrdinalIgnoreCase) = 0 AndAlso
+            ElseIf String.Compare(ST03, "005010X212", StringComparison.OrdinalIgnoreCase) = 0 AndAlso
                String.Compare(grp.FunctionalIdCode, "HN", StringComparison.Ordinal) = 0 Then
                 Return New Transactions.Transaction277.Standard_Obj("005010X212")
-            ElseIf String.Compare(rdr.Element(2), "005010X217", StringComparison.OrdinalIgnoreCase) = 0 AndAlso
+            ElseIf String.Compare(ST03, "005010X217", StringComparison.OrdinalIgnoreCase) = 0 AndAlso
                String.Compare(grp.FunctionalIdCode, "HI", StringComparison.Ordinal) = 0 Then
                 Return New Transactions.Transaction278.Standard_Obj("005010X217")
-            ElseIf String.Compare(rdr.Element(2), "005010X218", StringComparison.OrdinalIgnoreCase) = 0 AndAlso
+            ElseIf String.Compare(ST03, "005010X218", StringComparison.OrdinalIgnoreCase) = 0 AndAlso
                String.Compare(grp.FunctionalIdCode, "RA", StringComparison.Ordinal) = 0 Then
                 Return New Transactions.Transaction820.Standard_Obj("005010X218")
-            ElseIf String.Compare(rdr.Element(2), "005010X220A1", StringComparison.OrdinalIgnoreCase) = 0 AndAlso
+            ElseIf String.Compare(ST03, "005010X220A1", StringComparison.OrdinalIgnoreCase) = 0 AndAlso
                String.Compare(grp.FunctionalIdCode, "BE", StringComparison.Ordinal) = 0 Then
                 Return New Transactions.Transaction834.Standard_Obj("005010X220A1")
-            ElseIf String.Compare(rdr.Element(2), "005010X221A1", StringComparison.OrdinalIgnoreCase) = 0 AndAlso
+            ElseIf String.Compare(ST03, "005010X221A1", StringComparison.OrdinalIgnoreCase) = 0 AndAlso
                String.Compare(grp.FunctionalIdCode, "HP", StringComparison.Ordinal) = 0 Then
                 Return New Transactions.Transaction835.Standard_Obj("005010X221A1")
-            ElseIf String.Compare(rdr.Element(2), "005010X222A1", StringComparison.OrdinalIgnoreCase) = 0 AndAlso
+            ElseIf String.Compare(ST03, "005010X222A1", StringComparison.OrdinalIgnoreCase) = 0 AndAlso
                String.Compare(grp.FunctionalIdCode, "HC", StringComparison.Ordinal) = 0 Then
                 Return New Transactions.Transaction837.Standard_Obj("005010X222A1")
-            ElseIf String.Compare(rdr.Element(2), "005010X224A2", StringComparison.OrdinalIgnoreCase) = 0 AndAlso
+            ElseIf String.Compare(ST03, "005010X224A2", StringComparison.OrdinalIgnoreCase) = 0 AndAlso
                String.Compare(grp.FunctionalIdCode, "HC", StringComparison.Ordinal) = 0 Then
                 Return New Transactions.Transaction837.Standard_Obj("005010X224A2")
-            ElseIf String.Compare(rdr.Element(2), "005010X223A2", StringComparison.OrdinalIgnoreCase) = 0 AndAlso
+            ElseIf String.Compare(ST03, "005010X223A2", StringComparison.OrdinalIgnoreCase) = 0 AndAlso
                String.Compare(grp.FunctionalIdCode, "HC", StringComparison.Ordinal) = 0 Then
                 Return New Transactions.Transaction837.Standard_Obj("005010X223A2")
-            ElseIf String.Compare(rdr.Element(2), "005010X231", StringComparison.OrdinalIgnoreCase) = 0 AndAlso
+            ElseIf String.Compare(ST03, "005010X231", StringComparison.OrdinalIgnoreCase) = 0 AndAlso
                String.Compare(grp.FunctionalIdCode, "FA", StringComparison.Ordinal) = 0 Then
                 Return New Transactions.Transaction999.Standard_Obj("005010X231")
-            ElseIf String.Compare(rdr.Element(2), "005010X231A1", StringComparison.OrdinalIgnoreCase) = 0 AndAlso
+            ElseIf String.Compare(ST03, "005010X231A1", StringComparison.OrdinalIgnoreCase) = 0 AndAlso
                String.Compare(grp.FunctionalIdCode, "FA", StringComparison.Ordinal) = 0 Then
                 Return New Transactions.Transaction999.Standard_Obj("005010X231")
             End If

--- a/Madjic.Edi.Dom/Reader Support/EdiTransactionSetReader.vb
+++ b/Madjic.Edi.Dom/Reader Support/EdiTransactionSetReader.vb
@@ -44,6 +44,17 @@
             End Get
         End Property
 
+        ''' <summary>
+        ''' Gets the number of elements in the transaction set header segment.
+        ''' </summary>
+        ''' <value>The number of elements in the transaction set header segment.</value>
+        ''' <remarks></remarks>
+        Public ReadOnly Property ElementCount() As Integer
+            Get
+                Return DataSegment.Elements.Count
+            End Get
+        End Property
+
         Friend ReadOnly Property DataSegment As GenericSegment
 
         ''' <summary>


### PR DESCRIPTION
This fixes an index out of bounds exception if the ST segment omits ST03 (and therefore only has two elements). If omitted, we use GS08 instead of ST03.

I don't really do VB, and I'm not super familiar with this library, so I won't be offended if you don't merge this PR. If nothing else, I hope you see it as a template for how you might solve this issue.

FWIW, most (all?) of our 835 files simply omit ST03.